### PR TITLE
Update variable types and accept POST method on .authenticate

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-var Strategy = require('./strategy');
+const Strategy = require('./strategy');
 
 /**
  * Expose `Strategy` directly from package.

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -1,71 +1,65 @@
-var passport = require('passport-strategy')
-var crypto = require('crypto')
-var URL = require('url-parse')
-var aws = require('aws-sdk')
-var tokenstore = require('./tokenstore')
-var cache = {}
+const passport = require('passport-strategy')
+const crypto = require('crypto')
+const URL = require('url-parse')
+const aws = require('aws-sdk')
+const tokenstore = require('./tokenstore')
+const cache = {}
 
 function Strategy(options, verify) {
   options = options || {}
-  
+
   if (!options.accessKeyId || !options.secretAccessKey) {
     throw new Error('AWS access key and secret are required');
   }
-  
+
   if (!options.source) {
     throw new Error('Source email address is required')
   }
-  
+
   if (!options.hostname) {
     throw new Error('Hostname is required')
   }
-  
+
   if (!verify) {
     throw new Error('SES Strategy requires a verify callback')
   }
-  
+
   passport.Strategy.call(this);
-  
+
   this._client = new aws.SES({
     apiVersion: options.apiVersion || '2010-12-01',
     accessKeyId: options.accessKeyId,
     secretAccessKey: options.secretAccessKey,
     region: options.region || 'us-east-1',
   })
-  
+
   this._verify = verify;
-  
   this._source = options.source
-  
   this._passReqToCallback = options.passReqToCallback
-  
   this._signinSubject = options.signinSubject
-  
   this._tokenStore = options.tokenStore || tokenstore.createTokenStore()
-    
   this._baseUrl = new URL(options.hostname)
-  
-  this._baseUrl.scheme = options.scheme || 'https'  
+  this._baseUrl.scheme = options.scheme || 'https'
 }
 
 Strategy.prototype.authenticate = function(req, options) {
   options = options || {}
-  var token = req.query.token
-  var email = req.query.email
-  var self = this
-  
+  const token = req.query.token
+  const email = req.query.email
+  let self = this
+
   if (token) {
     self._tokenStore.get(token, function(err, foundToken) {
       if (err) { return self.error(err) }
-      
+
       if (!foundToken) {
         return self.fail({message: 'Invalid token'})
       }
-    
+
       if (!!foundToken.isValid && !foundToken.isValid()) {
         return self.fail({message: 'Expired token'})
       }
-      
+
       email = foundToken.email
       foundToken.destroy && foundToken.destroy()
 
@@ -84,23 +78,23 @@ Strategy.prototype.authenticate = function(req, options) {
       } catch(ex) {
         self.error(ex)
       }
-      
+
     })
-    
+
   } else {
     if (!email) {
       return self.fail(options.badRequestMessage || 'Missing email', 400);
     }
-    
+
     crypto.randomBytes(10, function(err, buf) {
       if (err) { return self.error(err); }
-      
+
       token = buf.toString('hex');
-      
+
       self._tokenStore.set(token, email, function(err, savedToken) {
-        
-        var requrl = new URL(req.url)
-        var tokenurl = new URL(self._baseUrl.toString())
+
+        const requrl = new URL(req.url)
+        const tokenurl = new URL(self._baseUrl.toString())
         tokenurl.pathname = requrl.pathname
         tokenurl.query = { token }
 
@@ -126,7 +120,7 @@ Strategy.prototype.authenticate = function(req, options) {
             self.pass()
           }
         })
-        
+
       })
     })
   }

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -44,7 +44,7 @@ function Strategy(options, verify) {
 
 Strategy.prototype.authenticate = function(req, options) {
   options = options || {}
-  const token = req.query.token || req.body.token
+  let token = req.query.token || req.body.token
   const email = req.query.email || req.body.email
   let self = this
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -45,7 +45,7 @@ function Strategy(options, verify) {
 Strategy.prototype.authenticate = function(req, options) {
   options = options || {}
   let token = req.query.token || req.body.token
-  const email = req.query.email || req.body.email
+  let email = req.query.email || req.body.email
   let self = this
 
   if (token) {
@@ -80,7 +80,6 @@ Strategy.prototype.authenticate = function(req, options) {
       }
 
     })
-
   } else {
     if (!email) {
       return self.fail(options.badRequestMessage || 'Missing email', 400);

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -44,8 +44,8 @@ function Strategy(options, verify) {
 
 Strategy.prototype.authenticate = function(req, options) {
   options = options || {}
-  const token = req.query.token
-  const email = req.query.email
+  const token = req.query.token || req.body.token
+  const email = req.query.email || req.body.email
   let self = this
 
   if (token) {

--- a/lib/tokenstore.js
+++ b/lib/tokenstore.js
@@ -7,7 +7,7 @@ function Token(value, email, options) {
   this._timestamp = new Date()
   this.value = value
   this.email = email
-  
+
   this.isValid = function() {
     return new Date() - this._timestamp < this._expirationDuration
   }
@@ -16,11 +16,11 @@ function Token(value, email, options) {
 module.exports = {
   createTokenStore: function(options) {
     options = options || {}
-    var store = {}
-    
+    const store = {}
+
     return {
       set: function(value, email, cb) {
-        var newToken = new Token(
+        const newToken = new Token(
           value,
           email,
           {expirationDuration: options.expirationDuration || (15 * 60 * 1000)} // 15 minutes


### PR DESCRIPTION
Hello,

I've started using this package and thanks, couple of things came to my attention, which one of them is using var instead of const for variables that won't change, the second is passport.authenticate is not working in endpoints where POST method is used due to req.query call, I thought querystring or body will solve that.